### PR TITLE
feat:添加翻译相关字段

### DIFF
--- a/grpc_api/bilibili/main/community/reply/v1/reply.proto
+++ b/grpc_api/bilibili/main/community/reply/v1/reply.proto
@@ -28,6 +28,8 @@ service Reply {
     rpc ShareRepliesInfo(ShareRepliesInfoReq) returns (ShareRepliesInfoResp);
     // 评论表情推荐列表接口
     rpc SuggestEmotes(SuggestEmotesReq) returns (SuggestEmotesResp);
+    // 翻译评论接口
+    rpc TranslateReply(TranslateReplyReq) returns (ReplyInfoReply);
 }
 
 // 活动
@@ -142,7 +144,7 @@ message CursorReply {
     // 排序方式
     // 2:时间 3:热度
     Mode mode = 5;
-    // 当前排序mode在切换按钮上的展示文案 
+    // 当前排序mode在切换按钮上的展示文案
     string mode_text = 6;
 }
 
@@ -855,6 +857,8 @@ message ReplyInfo {
     ReplyControl reply_control = 14;
     // 发布者信息V2
     MemberV2 member_v2 = 15;
+    // 翻译结果(仅在翻译请求中返回)
+    string translated_text = 17;
 }
 
 // 查询单条评论-响应
@@ -1238,4 +1242,14 @@ message Vote {
     string title = 2;
     // 参与人数
     int64 count = 3;
+}
+
+// 翻译评论请求
+message TranslateReplyReq {
+    // 业务type
+    int32 type = 1;
+    // 稿件id
+    int64 oid = 2;
+    // 评论id
+    int64 rpid = 3;
 }

--- a/grpc_api/bilibili/main/community/reply/v1/reply.proto
+++ b/grpc_api/bilibili/main/community/reply/v1/reply.proto
@@ -858,7 +858,7 @@ message ReplyInfo {
     // 发布者信息V2
     MemberV2 member_v2 = 15;
     // 翻译结果(仅在翻译请求中返回)
-    string translated_text = 17;
+    Content translated_text = 17;
 }
 
 // 查询单条评论-响应

--- a/proto/bilibili/main/community/reply/v1.proto
+++ b/proto/bilibili/main/community/reply/v1.proto
@@ -1380,6 +1380,8 @@ message ReplyControl {
     string context_feature = 35;
     // 
     InsertEffect insert_effect = 36;
+    // 是否显示翻译按钮，1: 显示，2: 不显示
+    int32 translate_state = 37;
 }
 
 // 
@@ -2175,4 +2177,3 @@ message TranslateReplyReq {
     // 评论id
     int64 rpid = 3;
 }
-

--- a/proto/bilibili/main/community/reply/v1.proto
+++ b/proto/bilibili/main/community/reply/v1.proto
@@ -39,6 +39,8 @@ service Reply {
     rpc ShareReplyMaterial (ShareReplyMaterialReq) returns (ShareReplyMaterialResp);
     // 
     rpc SuggestEmotes (SuggestEmotesReq) returns (SuggestEmotesResp);
+    // 翻译评论接口
+    rpc TranslateReply (TranslateReplyReq) returns (ReplyInfoReply);
     // 
     rpc UpdateSingleReplyNotificationConfig (UpdateSingleReplyNotificationConfigReq) returns (UpdateSingleReplyNotificationConfigResp);
     // 
@@ -1527,6 +1529,8 @@ message ReplyInfo {
     MemberV2 member_v2 = 15;
     // 
     string track_info = 16;
+    // 翻译结果(仅在翻译请求中返回)
+    string translated_text = 17;
 }
 
 // 
@@ -2160,5 +2164,15 @@ message VoteCard {
 message WordSearchParam {
     // 
     int64 shown_count = 1;
+}
+
+// 翻译评论请求
+message TranslateReplyReq {
+    // 业务type
+    int32 type = 1;
+    // 稿件id
+    int64 oid = 2;
+    // 评论id
+    int64 rpid = 3;
 }
 


### PR DESCRIPTION
- 刚才其实提过一个pr，但是那个是ai生成的，没测试过，所以撤了，现在这个已经过我个人[测试](https://github.com/bggRGjQaUbCoE/PiliPlus/pull/1894)
- 在添加翻译评论接口`rpc TranslateReply(TranslateReplyReq) returns (ReplyInfoReply);`
- 在`ReplyControl`中新增是否显示翻译按钮，1: 显示，2: 不显示`int32 translate_state = 37;`
- 在`ReplyInfo`中新增翻译结果(仅在翻译请求中返回)`string translated_text = 17;`